### PR TITLE
Endpoints return only needed data 

### DIFF
--- a/server/controllers/activity/getActivitiesController.js
+++ b/server/controllers/activity/getActivitiesController.js
@@ -1,24 +1,78 @@
 //server\controllers\activity\getActivitiesController.js
 const db = require("../../data/index.js");
 const Activity = db.Activity;
+const Task = db.Task;
+const Project = db.Project;
 const { Op } = db.Sequelize;
 const ApiError = require("../../utils/apiError");
+
+const NO_PROJECTS_FOUND = "No projects found for current user";
+const NO_TASKS_FOUND = "No tasks found for current user";
+const NO_ACTIVITIES_FOUND = "No activities found for current user";
+
+const getTasks = async (userId, isAdmin) => {
+  if (isAdmin) {
+    const tasks = await Task.findAll();
+    return tasks;
+  }
+
+  const projects = await Project.findAll({
+    where: {
+      creator_id: userId
+    }
+  });
+
+  if(projects.length === 0){
+    throw new ApiError(404, NO_PROJECTS_FOUND);
+  }
+
+  // Get all tasks for these projects
+  const tasks = await Task.findAll({
+    where: {
+      project_id: {
+        [Op.in]: projects.map((project) => project.id)
+      }
+    }
+  });
+
+  if(tasks.length === 0){
+    throw new ApiError(404, NO_TASKS_FOUND);
+  }
+
+  return tasks;
+};
 
 const getPaginatedActivities = async (req, res, next) => {
   const { _page = 1, _limit = 10, q = "" } = req.query;
   const offset = (parseInt(_page) - 1) * parseInt(_limit);
-  const whereClause = q ? { name: { [Op.like]: `%${q}%` } } : {};
+  const isAdmin = req.user.role === "admin";
 
-  try {
+  try {   
+    const tasks = await getTasks(req.user.id, isAdmin);
+
+    const whereClause = {
+      ...(q && { name: { [Op.like]: `%${q}%` } }),
+      ...(!isAdmin && {
+        id: {
+          [Op.in]: tasks.map((task) => task.activity_id)
+        }
+      })
+    };
+
+    // Get paginated activities for these tasks
     const { count: total, rows: data } = await Activity.findAndCountAll({
       where: whereClause,
       limit: parseInt(_limit),
       offset: offset
     });
 
+    if(data.length === 0){
+      throw new ApiError(404, NO_ACTIVITIES_FOUND);
+    }
+
     res.json({
       data,
-      total,
+      total, 
       page: parseInt(_page),
       limit: parseInt(_limit),
       totalPages: Math.ceil(total / parseInt(_limit))
@@ -32,12 +86,38 @@ const getPaginatedActivities = async (req, res, next) => {
   }
 };
 
-const getActivities = async (req, res) => {
+const getActivities = async (req, res, next) => {
+  const isAdmin = req.user.role === "admin";
+
   try {
-    const activities = await Activity.findAll();
+    if (isAdmin) {
+      const activities = await Activity.findAll();
+      return res.json(activities);
+    }
+
+    // Get all tasks for projects where user is creator
+    const tasks = await getTasks(req.user.id, isAdmin);
+
+    // Get all activities for these tasks
+    const activities = await Activity.findAll({
+      where: {
+        id: {
+          [Op.in]: tasks.map((task) => task.activity_id)
+        }
+      }
+    });
+
+    if(activities.length === 0){
+      throw new ApiError(404, NO_ACTIVITIES_FOUND);
+    }
+
     res.json(activities);
   } catch (error) {
-    throw new ApiError(500, "Internal server error!", error);
+    if (error instanceof ApiError) {
+      next(error);
+    } else {
+      next(new ApiError(500, "Internal server error!", error));
+    }
   }
 };
 

--- a/server/controllers/artisans/getArtisansController.js
+++ b/server/controllers/artisans/getArtisansController.js
@@ -1,6 +1,6 @@
 //server\controllers\artisans\getArtisansController.js
 const db = require("../../data/index.js");
-const { Artisan, Company, User, Task, Sequelize } = db;
+const { Artisan, Company, User, Task, Sequelize, Project } = db;
 const ApiError = require("../../utils/apiError");
 const { Op } = Sequelize;
 
@@ -8,16 +8,27 @@ const getPaginatedArtisans = async (req, res, next) => {
   try {
     const { _page = 1, _limit = 10, q = "" } = req.query;
     const offset = (parseInt(_page) - 1) * parseInt(_limit);
+    const isAdmin = req.user.role === "admin";
+
+    const users = await User.findAll({
+      where: {
+        manager_id: req.user.id
+      }
+    });
+
+    if (users.length === 0) {
+      throw new ApiError(404, "You are not authorized to access this resource");
+    }
 
     const whereClause = q
       ? {
-          name: {
-            [Op.like]: `%${q}%`
-          }
+        name: {
+          [Op.like]: `%${q}%`
         }
+      }
       : {};
 
-    const { count, rows } = await Artisan.findAndCountAll({
+    const rows = await Artisan.findAll({
       where: whereClause,
       include: [
         { model: Company, as: "company", attributes: ["name"] },
@@ -33,40 +44,86 @@ const getPaginatedArtisans = async (req, res, next) => {
       order: [["id", "DESC"]]
     });
 
+    const artisans = rows.filter((artisan) => {
+      if (isAdmin) {
+        return true;
+      }
+      return artisan.user_id === req.user.id;
+    });
+
     res.json({
-      artisans: rows,
-      artisansCount: count,
+      artisans: artisans,
+      artisansCount: artisans.length,
       page: parseInt(_page),
       limit: parseInt(_limit),
-      totalPages: Math.ceil(count / parseInt(_limit))
+      totalPages: Math.ceil(artisans.length / parseInt(_limit))
     });
   } catch (error) {
-    console.log(error);
+    if (error instanceof ApiError) {
+      next(error);
+    }
     next(new ApiError(500, "Internal server Error!"));
   }
 };
 
 const getArtisans = async (req, res, next) => {
   try {
-    const artisans = await Artisan.findAll({
-      include: [
-        {
-          model: Company,
-          as: "company",
-          attributes: ["name"]
-        },
-        {
-          model: User,
-          as: "user",
-          attributes: ["full_name"]
-        }
-      ],
-      order: [["id", "DESC"]]
+    const isAdmin = req.user.role === "admin";
+
+    const users = await User.findAll({
+      where: {
+        manager_id: req.user.id
+      }
     });
+
+    if (users.length === 0) {
+      throw new ApiError(404, "You are not authorized to access this resource");
+    }
+
+    let artisans;
+    if (!isAdmin) {
+      artisans = await Artisan.findAll({
+        include: [
+          {
+            model: Company,
+            as: "company",
+            attributes: ["name"]
+          },
+          {
+            model: User,
+            as: "user",
+            attributes: ["full_name"]
+          }
+        ],
+        where: {
+          user_id: {
+            [Op.in]: users.map((user) => user.id)
+          }
+        },
+        order: [["id", "DESC"]]
+      });
+    } else {
+      artisans = await Artisan.findAll({
+        include: [
+          {
+            model: Company,
+            as: "company",
+            attributes: ["name"]
+          },
+          {
+            model: User,
+            as: "user",
+            attributes: ["full_name"]
+          }
+        ]
+      });
+    }
 
     res.json(artisans);
   } catch (error) {
-    console.log(error);
+    if (error instanceof ApiError) {
+      next(error);
+    }
     next(new ApiError(500, "Internal server Error!"));
   }
 };

--- a/server/controllers/companies/getCompaniesController.js
+++ b/server/controllers/companies/getCompaniesController.js
@@ -1,6 +1,6 @@
 //server\controllers\companies\getCompaniesController.js
 const db = require("../../data/index.js");
-const { Company, Sequelize } = db;
+const { Company, Sequelize, Project } = db;
 const ApiError = require("../../utils/apiError");
 const { Op } = Sequelize;
 
@@ -8,9 +8,47 @@ const getPaginatedCompanies = async (req, res, next) => {
   try {
     const { _page = 1, _limit = 10, q = "" } = req.query;
     const offset = (parseInt(_page) - 1) * parseInt(_limit);
+    const isAdmin = req.user.role === "admin";
+
+    if(isAdmin){
+      const whereClause = q
+      ? {
+          name: {
+            [Op.like]: `%${q}%`
+          }
+        }
+      : {};
+
+      const companies = await Company.findAll({
+        where: whereClause,
+        limit: parseInt(_limit),
+        offset: offset
+      });
+
+      return res.json({
+        companies: companies,
+        companiesCount: companies.length,
+        page: parseInt(_page),
+        limit: parseInt(_limit),
+        totalPages: Math.ceil(companies.length / parseInt(_limit))
+      });
+    }
+
+    const projects = await Project.findAll({
+      where: {
+        creator_id: req.user.id
+      }
+    });
+
+    if(projects.length === 0){
+      throw new ApiError(404, "No projects found for current user");
+    }
 
     const whereClause = q
       ? {
+          id: {
+            [Op.in]: projects.map((project) => project.company_id)
+          },
           name: {
             [Op.like]: `%${q}%`
           }
@@ -32,7 +70,11 @@ const getPaginatedCompanies = async (req, res, next) => {
       totalPages: Math.ceil(count / parseInt(_limit))
     });
   } catch (error) {
-    next(new ApiError(500, "Internal server Error!"));
+    if (error instanceof ApiError) {
+      next(error);
+    } else {
+      next(new ApiError(500, "Internal server error!", error));
+    }
   }
 };
 

--- a/server/controllers/measures/getMeasuresController.js
+++ b/server/controllers/measures/getMeasuresController.js
@@ -1,11 +1,53 @@
 //server\controllers\measures\getMeasuresController.js\
 const ApiError = require("../../utils/apiError");
 const db = require("../../data/index.js");
-const { Measure } = db;
+const { Measure, Project, Task } = db;
 
 const getMeasures = async (req, res, next) => {
   try {
+    const isAdmin = req.user.role === "admin";
+
+    if(isAdmin){
+      const measures = await Measure.findAll({
+        order: [["name", "ASC"]]
+      });
+
+      return res.json({
+        success: true,
+        data: measures
+      });
+    }
+
+    const projects = await Project.findAll({
+      where: {
+        creator_id: req.user.id
+      }
+    });
+
+    if(projects.length === 0){
+      throw new ApiError(404, "No projects found for current user");
+    }
+
+    const tasks = await Task.findAll({
+      where: {
+        project_id: {
+          [Op.in]: projects.map((project) => project.id)
+        }
+      }
+    });
+
+    if(tasks.length === 0){
+      throw new ApiError(404, "No tasks found for current user");
+    }
+
+    const measureIds = tasks.map((task) => task.measure_id);
+
     const measures = await Measure.findAll({
+      where: {
+        id: {
+          [Op.in]: measureIds
+        }
+      },
       order: [["name", "ASC"]]
     });
 

--- a/server/controllers/projects/getProjectsController.js
+++ b/server/controllers/projects/getProjectsController.js
@@ -4,15 +4,19 @@ const { Project, Company } = db;
 const { Op } = require("sequelize");
 
 const getProjects = async (req, res, next) => {
-  console.log("Fetching all projects...");
-  console.log("User role:", req.user.role);
-  console.log("User ID:", req.user.id);
-  console.log("Search term:", req.query.search);
-
   try {
     let whereClause = {};
+    const isAdmin = req.user.role === "admin";
 
-    // Add search functionality
+    if(isAdmin){
+      const projects = await Project.findAll();
+      return res.json(projects);
+    }
+
+    if(projects.length === 0){
+      throw new ApiError(404, "No projects found for current user");
+    }
+
     if (req.query.search) {
       whereClause = {
         ...whereClause,
@@ -20,12 +24,7 @@ const getProjects = async (req, res, next) => {
       };
     }
 
-    // Add user role check
-    if (req.user.role !== "admin") {
-      whereClause.creator_id = req.user.id;
-    }
-
-    console.log("Where clause:", JSON.stringify(whereClause, null, 2));
+    whereClause.creator_id = req.user.id;
 
     const projects = await Project.findAll({
       attributes: ["id", "name", "company_id", "company_name", "email", "address", "location", "start_date", "end_date", "note", "status", "creator_id"],
@@ -33,11 +32,17 @@ const getProjects = async (req, res, next) => {
       order: [["id", "DESC"]]
     });
 
-    console.log("Number of projects found:", projects.length);
+    if(projects.length === 0){
+      throw new ApiError(404, "No projects found for current user");
+    }
+
     res.json(projects);
   } catch (error) {
-    console.error("Error fetching projects:", error);
-    next(error);
+    if (error instanceof ApiError) {
+      next(error);
+    } else {
+      next(new ApiError(500, "Internal server Error!"));
+    }
   }
 };
 

--- a/server/controllers/tasks/getTasksController.js
+++ b/server/controllers/tasks/getTasksController.js
@@ -1,10 +1,39 @@
 //server\controllers\tasks\getTasksController.js
 const db = require("../../data/index.js");
-const { Task, Artisan, Activity, Measure } = db;
+const { Task, Artisan, Activity, Measure, Project } = db;
 const ApiError = require("../../utils/apiError");
 
 const getTasks = async (req, res, next) => {
   try {
+    const isAdmin = req.user.role === "admin";
+    if(isAdmin){
+      const tasks = await Task.findAll({
+        where: { project_id: req.params.id },
+        include: [
+          {
+            model: Artisan,
+            as: "artisans",
+            through: { attributes: [] }
+          },
+          { model: Activity, as: "activity", attributes: ["name"] },
+          { model: Measure, as: "measure", attributes: ["name"] }
+        ],
+        order: [["id", "DESC"]]
+      });
+      return res.json(tasks);
+    }
+
+    const projects = await Project.findAll({
+      where: {
+        creator_id: req.user.id,
+        id: req.params.id
+      }
+    });
+
+    if(projects.length === 0){
+      throw new ApiError(404, "No projects found for current user");
+    }
+
     const tasks = await Task.findAll({
       where: { project_id: req.params.id },
       include: [
@@ -21,7 +50,11 @@ const getTasks = async (req, res, next) => {
 
     res.json(tasks);
   } catch (error) {
-    next(new ApiError(500, "Internal server Error!"));
+    if (error instanceof ApiError) {
+      next(error);
+    } else {
+      next(new ApiError(500, "Internal server Error!"));
+    }
   }
 };
 

--- a/server/controllers/user/getUsersController.js
+++ b/server/controllers/user/getUsersController.js
@@ -5,7 +5,6 @@ const { Op } = db.Sequelize;
 const ApiError = require("../../utils/apiError");
 
 const getUsers = async (req, res, next) => {
-  console.log("Fetching users with role:", req.user.role);
   const { _page = 1, _limit = 10, q = "" } = req.query;
   const offset = (parseInt(_page) - 1) * parseInt(_limit);
   const searchTerm = q ? `%${q}%` : null;
@@ -13,7 +12,6 @@ const getUsers = async (req, res, next) => {
 
   try {
     const whereClause = buildWhereClause(req.user.role, currentUserId, searchTerm);
-    console.log("Where clause:", whereClause);
 
     const { count: usersCount, rows: users } = await User.findAndCountAll({
       where: whereClause,
@@ -26,7 +24,6 @@ const getUsers = async (req, res, next) => {
       ]
     });
 
-    console.log("Found users count:", usersCount);
     res.status(200).json({
       users,
       usersCount,
@@ -35,8 +32,11 @@ const getUsers = async (req, res, next) => {
       totalPages: Math.ceil(usersCount / parseInt(_limit))
     });
   } catch (error) {
-    console.error("Error fetching users:", error);
-    next(new ApiError(500, "Internal server error", error));
+    if (error instanceof ApiError) {
+      next(error);
+    } else {
+      next(new ApiError(500, "Internal server error", error));
+    }
   }
 };
 

--- a/server/controllers/workItems/getWorkItemsController.js
+++ b/server/controllers/workItems/getWorkItemsController.js
@@ -1,6 +1,6 @@
 //server\controllers\workItems\getWorkItemsController.js
 const db = require("../../data/index.js");
-const { WorkItem, Task, Artisan } = db;
+const { WorkItem, Task, Artisan, Project } = db;
 const ApiError = require("../../utils/apiError");
 
 const getWorkItems = async (req, res, next) => {
@@ -8,12 +8,32 @@ const getWorkItems = async (req, res, next) => {
   const { _page = 1, _limit = 4 } = req.query;
 
   const offset = (_page - 1) * _limit;
+  const isAdmin = req.user.role === "admin";
 
   try {
-    console.log("Fetching work items for task_id:", task_id);
+    if(isAdmin){
+      const workItems = await WorkItem.findAll();
+      return res.json(workItems);
+    }
+
+    const projects = await Project.findAll({
+      where: {
+        creator_id: req.user.id,
+        id: req.params.project_id
+      }
+    });
+
+    if(projects.length === 0){
+      throw new ApiError(404, "No projects found for current user");
+    }
+
+    const taskIds = projects.map((project) => project.task_id);
+    if(taskIds.length === 0){
+      throw new ApiError(404, "No tasks found for current user");
+    }
 
     const workItems = await WorkItem.findAndCountAll({
-      where: { task_id },
+      where: { task_id: { [Op.in]: taskIds } },
       include: [
         {
           model: Task,
@@ -33,8 +53,6 @@ const getWorkItems = async (req, res, next) => {
       order: [["id", "DESC"]]
     });
 
-    console.log("Successfully fetched work items:", workItems.count);
-
     res.json({
       workItems: workItems.rows,
       workItemsCount: workItems.count,
@@ -43,8 +61,11 @@ const getWorkItems = async (req, res, next) => {
       totalPages: Math.ceil(workItems.count / parseInt(_limit))
     });
   } catch (error) {
-    console.log("Error fetching work items:", error);
-    next(new ApiError(500, "Internal server Error!"));
+    if (error instanceof ApiError) {
+      next(error);
+    } else {
+      next(new ApiError(500, "Internal server Error!"));
+    }
   }
 };
 


### PR DESCRIPTION
Modified already existing endpoints to return only data which should be accessible only by specific artisans/manager. The admin has an access to all data from database. Managers have access only to their projects, activities, companies, measures, work items, tasks and artisans. The other data is not anymore accessible due to authorization rights.